### PR TITLE
feat(controller): No rollback to bad revision via patch PT2 (read RS state)

### DIFF
--- a/docs/features/rollback.md
+++ b/docs/features/rollback.md
@@ -4,8 +4,9 @@
 
     Available for blue-green and canary rollouts since v1.4
 
-By default, when an older Rollout manifest is re-applied, the controller treats it the same as a spec change, and will execute the full list of steps, and perform analysis too. There are two exceptions to this rule: 
-1. the controller detects if it is moving back to a blue-green ReplicaSet which exists and is still scaled up (within its `scaleDownDelay`) 
+By default, when an older Rollout manifest is re-applied, the controller treats it the same as a spec change, and will execute the full list of steps, and perform analysis too. There are two exceptions to this rule:
+
+1. the controller detects if it is moving back to a blue-green ReplicaSet which exists and is still scaled up (within its `scaleDownDelay`)
 2. the controller detects it is moving back to the canary's "stable" ReplicaSet, and the upgrade had not yet completed.
 
 It is often undesirable to re-run analysis and steps for a rollout, when the desired behavior is to rollback as soon as possible. To help with this, a rollback window feature allows users to indicate that the promotion to the ReplicaSet within the window will skip all steps.
@@ -21,3 +22,25 @@ spec:
 ```
 
 Assume a linear revision history: `1`, `2`, `3`, `4`, `5 (current)`. A rollback from revision 5 back to 4 or 3 will fall within the window, so it will be fast tracked.
+
+!!! important
+
+  Bad ReplicaSet rollback protection turned on for blue-green and canary rollouts since v1.9
+
+Bad ReplicaSet rollback protect ensures that a replicaset that has an historical abort event associated with it will not be allowed to undergo a fast rollback and skip all steps.
+
+Example using the same `rollbackWindow` of `3` above:
+
+1. Assume a linear revision history with these revisions:
+  `1(good) - 2(good) - 3(good)(stable)`
+2. A deployment starts then gets aborted so now we have:
+  `2(good) - 3(good)(stable) - 4(aborted)(canary)`
+3. A change to fix the aborted version is made:
+  `3(good) - 4(aborted)(bad) - 5(good)(stable)`
+4. This sets up a condition where a fast rollback from version `6` to version `4` would be permitted pre 1.9
+
+!!! note
+
+    The window is not dynamic based on aborted/good replicasets. This means that in the above example,
+    we would _not_ extend the `rollbackWindow` to include revision `2`. ReplicaSet instances that are determined
+    to be invalid are simply filtered from the already calculated window.

--- a/rollout/analysis.go
+++ b/rollout/analysis.go
@@ -74,7 +74,7 @@ func (c *rolloutContext) reconcileAnalysisRuns() error {
 	isAborted := c.pauseContext.IsAborted()
 	rollbackToScaleDownDelay := replicasetutil.HasScaleDownDeadline(c.newRS)
 	initialDeploy := c.rollout.Status.StableRS == ""
-	isRollbackWithinWindow := c.isRollbackWithinWindow()
+	isRollbackWithinWindow := c.isRollbackWithinWindowAndValid()
 	if isAborted || c.rollout.Status.PromoteFull || rollbackToScaleDownDelay || initialDeploy || isRollbackWithinWindow {
 		c.log.Infof("Skipping analysis: isAborted: %v, promoteFull: %v, rollbackToScaleDownDelay: %v, initialDeploy: %v, isRollbackWithinWindow: %v", isAborted, c.rollout.Status.PromoteFull, rollbackToScaleDownDelay, initialDeploy, isRollbackWithinWindow)
 		allArs := append(c.currentArs.ToArray(), c.otherArs...)

--- a/rollout/bluegreen.go
+++ b/rollout/bluegreen.go
@@ -272,7 +272,7 @@ func (c *rolloutContext) syncRolloutStatusBlueGreen(previewSvc *corev1.Service, 
 	if replicasetutil.CheckPodSpecChange(c.rollout, c.newRS) {
 		c.resetRolloutStatus(&newStatus)
 	}
-	if c.rollout.Status.PromoteFull || c.isRollbackWithinWindow() {
+	if c.rollout.Status.PromoteFull || c.isRollbackWithinWindowAndValid() {
 		c.pauseContext.ClearPauseConditions()
 		c.pauseContext.RemoveAbort()
 	}

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -1078,12 +1078,6 @@ func TestBlueGreenRolloutScaleUpdateStableRS(t *testing.T) {
 	f.expectUpdateReplicaSetAction(rs2)
 
 	f.run(getKey(r2, t))
-
-	// // validate final status for replica set is success
-	// updatedRs2 := f.getUpdatedReplicaSet(updateRs2Index)
-	// assert.NotNil(t, updatedRs2)
-	// assert.Equal(t, FinalStatusSuccess, updatedRs2.GetObjectMeta().GetAnnotations()[v1alpha1.ReplicaSetFinalStatusKey])
-
 }
 
 func TestBlueGreenStableRSReconciliationShouldNotScaleOnFirstTimeRollout(t *testing.T) {
@@ -1165,8 +1159,6 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 		f.serviceLister = append(f.serviceLister, activeSvc)
 
 		patchIndex := f.expectPatchRolloutAction(r1)
-		// this doesn't feel like it should be "success" or done yet
-		// updateRsIndex := f.expectUpdateReplicaSetAction(rs1) // set final status of RS
 		f.run(getKey(r2, t))
 
 		patch := f.getPatchedRollout(patchIndex)

--- a/rollout/bluegreen_test.go
+++ b/rollout/bluegreen_test.go
@@ -1078,6 +1078,12 @@ func TestBlueGreenRolloutScaleUpdateStableRS(t *testing.T) {
 	f.expectUpdateReplicaSetAction(rs2)
 
 	f.run(getKey(r2, t))
+
+	// // validate final status for replica set is success
+	// updatedRs2 := f.getUpdatedReplicaSet(updateRs2Index)
+	// assert.NotNil(t, updatedRs2)
+	// assert.Equal(t, FinalStatusSuccess, updatedRs2.GetObjectMeta().GetAnnotations()[v1alpha1.ReplicaSetFinalStatusKey])
+
 }
 
 func TestBlueGreenStableRSReconciliationShouldNotScaleOnFirstTimeRollout(t *testing.T) {
@@ -1159,6 +1165,8 @@ func TestPreviewReplicaCountHandleScaleUpPreviewCheckPoint(t *testing.T) {
 		f.serviceLister = append(f.serviceLister, activeSvc)
 
 		patchIndex := f.expectPatchRolloutAction(r1)
+		// this doesn't feel like it should be "success" or done yet
+		// updateRsIndex := f.expectUpdateReplicaSetAction(rs1) // set final status of RS
 		f.run(getKey(r2, t))
 
 		patch := f.getPatchedRollout(patchIndex)

--- a/rollout/canary.go
+++ b/rollout/canary.go
@@ -396,7 +396,7 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 				// If we get here, we detected that we've moved back to the stable ReplicaSet
 				c.recorder.Eventf(c.rollout, record.EventOptions{EventReason: "SkipSteps"}, "Rollback to stable ReplicaSets")
 				newStatus.CurrentStepIndex = &stepCount
-			} else if c.isRollbackWithinWindow() && replicasetutil.IsActive(c.newRS) {
+			} else if c.isRollbackWithinWindowAndValid() && replicasetutil.IsActive(c.newRS) {
 				// Else if we get here we detected that we are within the rollback window we can skip steps and move back to the active ReplicaSet
 				c.recorder.Eventf(c.rollout, record.EventOptions{EventReason: "SkipSteps"}, "Rollback to active ReplicaSets within RollbackWindow")
 				newStatus.CurrentStepIndex = &stepCount
@@ -407,7 +407,7 @@ func (c *rolloutContext) syncRolloutStatusCanary() error {
 		return c.persistRolloutStatus(&newStatus)
 	}
 
-	if c.rollout.Status.PromoteFull || c.isRollbackWithinWindow() {
+	if c.rollout.Status.PromoteFull || c.isRollbackWithinWindowAndValid() {
 		c.pauseContext.ClearPauseConditions()
 		c.pauseContext.RemoveAbort()
 		if stepCount > 0 {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -908,7 +908,7 @@ func (c *rolloutContext) resetRolloutStatus(newStatus *v1alpha1.RolloutStatus) {
 }
 
 func (c *rolloutContext) isRollbackWithinWindowAndValid() bool {
-	return c.isRollbackWithinWindowAndValid() && c.isfinalStatusValid()
+	return c.isRollbackWithinWindow() && c.isfinalStatusValid()
 }
 
 func (c *rolloutContext) isfinalStatusValid() bool {

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -908,13 +908,13 @@ func (c *rolloutContext) resetRolloutStatus(newStatus *v1alpha1.RolloutStatus) {
 }
 
 func (c *rolloutContext) isRollbackWithinWindowAndValid() bool {
-	return c.isRollbackWithinWindow() && c.isfinalStatusValid()
+	return c.isRollbackWithinWindow() && c.isRSStateValid()
 }
 
-func (c *rolloutContext) isfinalStatusValid() bool {
+func (c *rolloutContext) isRSStateValid() bool {
 	if c.newRS != nil && c.newRS.Annotations != nil {
-		finalStatus := c.newRS.Annotations[v1alpha1.ReplicaSetStateKey]
-		return finalStatus != RSStateAbort
+		RSState := c.newRS.Annotations[v1alpha1.ReplicaSetStateKey]
+		return RSState != RSStateAbort
 	}
 	return true
 }

--- a/rollout/sync.go
+++ b/rollout/sync.go
@@ -913,8 +913,8 @@ func (c *rolloutContext) isRollbackWithinWindowAndValid() bool {
 
 func (c *rolloutContext) isfinalStatusValid() bool {
 	if c.newRS != nil && c.newRS.Annotations != nil {
-		finalStatus := c.newRS.Annotations[v1alpha1.ReplicaSetFinalStatusKey]
-		return finalStatus != FinalStatusAbort
+		finalStatus := c.newRS.Annotations[v1alpha1.ReplicaSetStateKey]
+		return finalStatus != RSStateAbort
 	}
 	return true
 }

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -627,7 +627,7 @@ func Test_isRollbackWithinWindowAndValid(t *testing.T) {
 			}
 			ctx.log = logutil.WithRollout(ctx.rollout)
 			assert.Equal(t, test.expectedWithin, ctx.isRollbackWithinWindow())
-			assert.Equal(t, test.expectedisValid, ctx.isfinalStatusValid())
+			assert.Equal(t, test.expectedisValid, ctx.isRSStateValid())
 			assert.Equal(t, test.expectedWithin && test.expectedisValid, ctx.isRollbackWithinWindowAndValid())
 		})
 	}

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -464,26 +464,52 @@ func TestSendStateChangeEvents(t *testing.T) {
 	}
 }
 
-// TestRollbackWindow verifies the rollback window conditions
-func TestRollbackWindow(t *testing.T) {
+func Test_isRollbackWithinWindowAndValid(t *testing.T) {
 	now := timeutil.MetaNow()
 
 	replicaSets := []*appsv1.ReplicaSet{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "foo-4",
-				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute * 5)},
+				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute * 8)},
+				Annotations: map[string]string{
+					v1alpha1.ReplicaSetStateKey: RSStateSuccess,
+				},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "foo-3",
-				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute * 4)},
+				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute * 7)},
+				Annotations: map[string]string{
+					v1alpha1.ReplicaSetStateKey: RSStateAbort,
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "foo-4",
+				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute * 6)},
+				Annotations: map[string]string{
+					v1alpha1.ReplicaSetStateKey: RSStateSuccess,
+				},
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "foo-2",
+				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute * 5)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "foo-1",
+				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute * 4)},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "foo-1",
 				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute * 3)},
 			},
 		},
@@ -496,7 +522,7 @@ func TestRollbackWindow(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "foo-experiment",
-				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute)},
+				CreationTimestamp: metav1.Time{Time: now.Add(-time.Minute * 1)},
 				Annotations: map[string]string{
 					v1alpha1.ExperimentNameAnnotationKey: "my-experiment",
 				},
@@ -510,55 +536,100 @@ func TestRollbackWindow(t *testing.T) {
 		},
 	}
 	testRuns := []struct {
-		stableRS       *appsv1.ReplicaSet
-		newRS          *appsv1.ReplicaSet
-		revisionWindow int32
-		expectedWithin bool
+		testName        string
+		stableRS        *appsv1.ReplicaSet
+		newRS           *appsv1.ReplicaSet
+		revisionWindow  int32
+		expectedWithin  bool
+		expectedisValid bool
 	}{
+		// no stable and no new rs
 		{
-			replicaSets[0], nil, 1, false,
+			"stableRS and newRS are nil", nil, nil, 3, false, true,
 		},
+		// no stable rs
 		{
-			replicaSets[0], replicaSets[1], 1, false,
+			"stableRS is nil", nil, replicaSets[3], 3, false, true,
 		},
+		// no new rs
 		{
-			replicaSets[1], replicaSets[0], 1, true,
+			"newRS is nil", replicaSets[3], nil, 3, false, true,
 		},
+		// validate legacy behavior (no final status set)
+		// new rs created after stable rs (not a rollback)
 		{
-			replicaSets[2], replicaSets[0], 2, true,
+			"not a rollback", replicaSets[3], replicaSets[4], 1, false, true,
 		},
+		// is a rollback and within window, window of 1
 		{
-			replicaSets[3], replicaSets[0], 2, false,
+			"rollback within window of 1", replicaSets[4], replicaSets[3], 1, true, true,
+		},
+		// is a rollback and within window, window of N where N is not 1
+		{
+			"rollback within window of N", replicaSets[5], replicaSets[3], 2, true, true,
+		},
+		// is a rollback outside of window, window of N where N is not 1
+		{
+			"rollback outside window of N", replicaSets[6], replicaSets[3], 2, false, true,
 		},
 		// from 5->3 the window is 1 because experiments are excluded
 		{
-			replicaSets[5], replicaSets[3], 1, true,
+			"experiments should be exclude from window count", replicaSets[8], replicaSets[6], 1, true, true,
 		},
+
+		// validate new behavior where rollback should not be fast
+		// stableRS final-status "success" -> newRS final-status "abort"
+		// new rs created after stable rs (not a rollback)
+		{
+			"Not a rollback; final-status annotation success present; valid is true", replicaSets[0], replicaSets[1], 1, false, false,
+		},
+		// is a rollback and within window, window of 1
+		{
+			"rollback within window of 1; final-status annotation abort present; valid is false", replicaSets[2], replicaSets[1], 1, true, false,
+		},
+		// is a rollback and within window, window of N where N is not 1
+		{
+			"rollback within window of 1; final-status annotation abort present; valid is false", replicaSets[3], replicaSets[1], 2, true, false,
+		},
+		// is a rollback outside of window, window of N where N is not 1
+		{
+			"rollback outside window of N; final-status annotation abort present; valid is false", replicaSets[4], replicaSets[1], 2, false, false,
+		},
+		// from 5->3 the window is 1 because experiments are excluded
+		{
+			"experiments should be exclude from window count; final-status annotation abort present; valid is false", replicaSets[8], replicaSets[1], 6, true, false,
+		},
+
+		// validate new behavior where rollback should be fast
+		// stableRS final-status "abort" -> newRS final-status "success"
+
+		// validate new behavior where rollback should be fast
+		// stableRS final-status "success" -> newRS final-status "success"
 	}
 	for _, test := range testRuns {
-		ctx := &rolloutContext{
-			allRSs:   replicaSets,
-			newRS:    test.newRS,
-			stableRS: test.stableRS,
-		}
+		t.Run(test.testName, func(t *testing.T) {
+			ctx := &rolloutContext{
+				allRSs:   replicaSets,
+				newRS:    test.newRS,
+				stableRS: test.stableRS,
+			}
 
-		ctx.rollout = &v1alpha1.Rollout{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: "default",
-			},
-			Spec: v1alpha1.RolloutSpec{
-				RollbackWindow: &v1alpha1.RollbackWindowSpec{
-					Revisions: test.revisionWindow,
+			ctx.rollout = &v1alpha1.Rollout{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
 				},
-			},
-		}
-		ctx.log = logutil.WithRollout(ctx.rollout)
-		if test.expectedWithin {
-			assert.True(t, ctx.isRollbackWithinWindowAndValid())
-		} else {
-			assert.False(t, ctx.isRollbackWithinWindowAndValid())
-		}
+				Spec: v1alpha1.RolloutSpec{
+					RollbackWindow: &v1alpha1.RollbackWindowSpec{
+						Revisions: test.revisionWindow,
+					},
+				},
+			}
+			ctx.log = logutil.WithRollout(ctx.rollout)
+			assert.Equal(t, test.expectedWithin, ctx.isRollbackWithinWindow())
+			assert.Equal(t, test.expectedisValid, ctx.isfinalStatusValid())
+			assert.Equal(t, test.expectedWithin && test.expectedisValid, ctx.isRollbackWithinWindowAndValid())
+		})
 	}
 }
 

--- a/rollout/sync_test.go
+++ b/rollout/sync_test.go
@@ -555,9 +555,9 @@ func TestRollbackWindow(t *testing.T) {
 		}
 		ctx.log = logutil.WithRollout(ctx.rollout)
 		if test.expectedWithin {
-			assert.True(t, ctx.isRollbackWithinWindow())
+			assert.True(t, ctx.isRollbackWithinWindowAndValid())
 		} else {
-			assert.False(t, ctx.isRollbackWithinWindow())
+			assert.False(t, ctx.isRollbackWithinWindowAndValid())
 		}
 	}
 }


### PR DESCRIPTION
Background
=====

- Enhancement proposal by @zachaller is here https://github.com/argoproj/argo-rollouts/issues/3039 with a clear writeup
- In the current state of things, if there is an aborted canary deployment in the `ReplicaSet` history, a later fast rollback could in theory rollback to a previously aborted/failed revision. This is preventable by marking a bad/aborted `ReplicaSet` and filtering it from the `ReplicaSet` list available for a fast rollback window.

Modifications
=====
- utilize annotation key named `"argo-rollouts.argoproj.io/state"` added in [this PR](https://github.com/argoproj/argo-rollouts/pull/4281) in evaluating fast rollbacks
- Fast rollbacks must pass an `isRSStateValid` check as well as the preexisting `isRollbackWithinWindow` check.
- slight cleanup of triple nested `if` conditions in `isRollbackWithinWindow` to make the reading slightly more simple (IMO)


Checklist:

* [x] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-rollouts/issues/3039) and discussed it with the community, (b) this is a bug fix, or (c) this is a chore.
* [x] The title of the PR is (a) [conventional](https://www.conventionalcommits.org/en/v1.0.0/) with a list of types and scopes found [here](https://github.com/argoproj/argo-rollouts/blob/master/.github/workflows/pr-title-check.yml), (b) states what changed, and (c) suffixes the related issues number. E.g. `"fix(controller): Updates such and such. Fixes #1234"`.  
* [x] I've signed my commits with [DCO](https://github.com/argoproj/argoproj/blob/main/community/CONTRIBUTING.md#legal)
* [x] I have written unit and/or e2e tests for my change. PRs without these are unlikely to be merged.
* [x] My builds are green. Try syncing with master if they are not. 
* [ ] My organization is added to [USERS.md](https://github.com/argoproj/argo-rollouts/blob/master/USERS.md).
